### PR TITLE
in backend class use `self` instead of class

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -168,7 +168,7 @@ class AdfsBackend(ModelBackend):
 
         payload = None
 
-        for idx, key in enumerate(self._public_keys):
+        for idx, key in enumerate(self.__class__._public_keys):
             try:
                 # Explicitly define the verification option
                 # The list below is the default the jwt module uses.
@@ -199,7 +199,7 @@ class AdfsBackend(ModelBackend):
                 raise PermissionDenied
             except jwt.DecodeError as error:
                 # If it's not the last certificate in the list, skip to the next one
-                if idx < len(self._public_keys)-1:
+                if idx < len(self.__class__._public_keys) - 1:
                     continue
                 else:
                     logger.info('Error decoding signature: %s' % error)

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -40,7 +40,7 @@ class AdfsBackend(ModelBackend):
         if not settings.SIGNING_CERT:
             raise ImproperlyConfigured("ADFS token signing certificate not set")
         cert_exp_time = datetime.now() - timedelta(hours=settings.CERT_MAX_AGE)
-        if len(type(self)._public_keys) < 1 or type(self)._key_age < cert_exp_time:
+        if len(self.__class__._public_keys) < 1 or self.__class__._key_age < cert_exp_time:
             if settings.SIGNING_CERT is True:
                 self._autoload()
             elif isfile(settings.SIGNING_CERT):

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -40,7 +40,7 @@ class AdfsBackend(ModelBackend):
         if not settings.SIGNING_CERT:
             raise ImproperlyConfigured("ADFS token signing certificate not set")
         cert_exp_time = datetime.now() - timedelta(hours=settings.CERT_MAX_AGE)
-        if len(AdfsBackend._public_keys) < 1 or AdfsBackend._key_age < cert_exp_time:
+        if len(self._public_keys) < 1 or self._key_age < cert_exp_time:
             if settings.SIGNING_CERT is True:
                 self._autoload()
             elif isfile(settings.SIGNING_CERT):

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -40,7 +40,7 @@ class AdfsBackend(ModelBackend):
         if not settings.SIGNING_CERT:
             raise ImproperlyConfigured("ADFS token signing certificate not set")
         cert_exp_time = datetime.now() - timedelta(hours=settings.CERT_MAX_AGE)
-        if len(self._public_keys) < 1 or self._key_age < cert_exp_time:
+        if len(type(self)._public_keys) < 1 or type(self)._key_age < cert_exp_time:
             if settings.SIGNING_CERT is True:
                 self._autoload()
             elif isfile(settings.SIGNING_CERT):


### PR DESCRIPTION
In `django_auth_adfs.backend.AdfsBackend` If you want to use class attribute `self` should be used, not `AdfsBackend`.