### PR TITLE
Fix LoginRequiredMiddleware for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
           env: TOXENV=py34-django110
         - python: 3.4
           env: TOXENV=py34-django111
+        - python: 3.4
+          env: TOXENV=py34-django20a1
         - python: 3.5
           env: TOXENV=py35-django18
         - python: 3.5
@@ -27,6 +29,8 @@ matrix:
           env: TOXENV=py35-django110
         - python: 3.5
           env: TOXENV=py35-django111
+        - python: 3.5
+          env: TOXENV=py35-django20a1
         - python: 3.6
           env: TOXENV=py36-django18
         - python: 3.6
@@ -35,9 +39,11 @@ matrix:
           env: TOXENV=py36-django110
         - python: 3.6
           env: TOXENV=py36-django111
-        - python: 3.5
+        - python: 3.6
+          env: TOXENV=py36-django20a1
+        - python: 3.6
           env: TOXENV=flake8
-        - python: 3.5
+        - python: 3.6
           env: TOXENV=docs
 
 # command to install dependencies for getting Tox running, other dependencies are installed by Tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ matrix:
           env: TOXENV=py36-django111
         - python: 3.6
           env: TOXENV=py36-django20a1
-        - python: 3.6
+        - python: 3.5
           env: TOXENV=flake8
-        - python: 3.6
+        - python: 3.5
           env: TOXENV=docs
 
 # command to install dependencies for getting Tox running, other dependencies are installed by Tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           env: TOXENV=py27-django110
         - python: 2.7
           env: TOXENV=py27-django111
+
         - python: 3.4
           env: TOXENV=py34-django18
         - python: 3.4
@@ -20,9 +21,8 @@ matrix:
         - python: 3.4
           env: TOXENV=py34-django111
         - python: 3.4
-          env: TOXENV=py34-django20a1
-        - python: 3.4
-          env: TOXENV=py34-django20b1
+          env: TOXENV=py34-django20
+
         - python: 3.5
           env: TOXENV=py35-django18
         - python: 3.5
@@ -32,9 +32,8 @@ matrix:
         - python: 3.5
           env: TOXENV=py35-django111
         - python: 3.5
-          env: TOXENV=py35-django20a1
-        - python: 3.5
-          env: TOXENV=py35-django20b1
+          env: TOXENV=py35-django20
+
         - python: 3.6
           env: TOXENV=py36-django18
         - python: 3.6
@@ -44,11 +43,11 @@ matrix:
         - python: 3.6
           env: TOXENV=py36-django111
         - python: 3.6
-          env: TOXENV=py36-django20a1
-        - python: 3.6
-          env: TOXENV=py36-django20b1
+          env: TOXENV=py36-django20
+
         - python: 3.5
           env: TOXENV=flake8
+
         - python: 3.5
           env: TOXENV=docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
           env: TOXENV=py34-django111
         - python: 3.4
           env: TOXENV=py34-django20a1
+        - python: 3.4
+          env: TOXENV=py34-django20b1
         - python: 3.5
           env: TOXENV=py35-django18
         - python: 3.5
@@ -31,6 +33,8 @@ matrix:
           env: TOXENV=py35-django111
         - python: 3.5
           env: TOXENV=py35-django20a1
+        - python: 3.5
+          env: TOXENV=py35-django20b1
         - python: 3.6
           env: TOXENV=py36-django18
         - python: 3.6
@@ -41,6 +45,8 @@ matrix:
           env: TOXENV=py36-django111
         - python: 3.6
           env: TOXENV=py36-django20a1
+        - python: 3.6
+          env: TOXENV=py36-django20b1
         - python: 3.5
           env: TOXENV=flake8
         - python: 3.5

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -44,7 +44,7 @@ class LoginRequiredMiddleware(MiddlewareMixin):
                                          " If that doesn't work, ensure your TEMPLATE_CONTEXT_PROCESSORS" \
                                          " setting includes 'django.core.context_processors.auth'."
 
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in LOGIN_EXEMPT_URLS):
                 return HttpResponseRedirect(get_adfs_auth_url())

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -54,4 +54,3 @@ class LoginRequiredMiddleware(MiddlewareMixin):
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in LOGIN_EXEMPT_URLS):
                 return HttpResponseRedirect(get_adfs_auth_url())
-            

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -1,6 +1,7 @@
 """
 Based on https://djangosnippets.org/snippets/1179/
 """
+import django
 from django.conf import settings as django_settings
 from django.http import HttpResponseRedirect
 from re import compile
@@ -44,7 +45,13 @@ class LoginRequiredMiddleware(MiddlewareMixin):
                                          " If that doesn't work, ensure your TEMPLATE_CONTEXT_PROCESSORS" \
                                          " setting includes 'django.core.context_processors.auth'."
 
-        if not request.user.is_authenticated:
+        if django.VERSION[:2] < (1, 10):
+            user_authenticated = request.user.is_authenticated()
+        else:
+            user_authenticated = request.user.is_authenticated
+
+        if not user_authenticated:
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in LOGIN_EXEMPT_URLS):
                 return HttpResponseRedirect(get_adfs_auth_url())
+            

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,6 +19,7 @@ And with the following Django versions:
 * 1.9
 * 1.10
 * 1.11
+* 2.0
 
 You will also need the following:
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'Intended Audience :: End Users/Desktop',
         'Operating System :: OS Independent',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,17 +29,18 @@ TEMPLATES = [
     },
 ]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     'django_auth_adfs.middleware.LoginRequiredMiddleware',
 )
+# Django < 1.10 compatibility
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 INSTALLED_APPS = (
     'django.contrib.admin',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{18,19,110,111,20a1},flake8,docs
+envlist = py{27,34,35,36}-django{18,19,110,111},py{34,35,36}-django{20a1,20b1},flake8,docs
 
 [testenv]
 setenv =
@@ -13,6 +13,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     django20a1: Django>=2.0a1,<2.0a2
+    django20b1: Django>=2.0b1,<2.0b2
 commands =
     coverage run --source=django_auth_adfs manage.py test -v 2
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{18,19,110,111},py{34,35,36}-django{20a1,20b1},flake8,docs
+envlist = py{27,34,35,36}-django{18,19,110,111},py{34,35,36}-django{20},flake8,docs
 
 [testenv]
 setenv =
@@ -12,8 +12,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
-    django20a1: Django>=2.0a1,<2.0a2
-    django20b1: Django>=2.0b1,<2.0b2
+    django20: Django>=2.0a1,<2.1
 commands =
     coverage run --source=django_auth_adfs manage.py test -v 2
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{18,19,110,111},flake8,docs
+envlist = py{27,34,35,36}-django{18,19,110,111,20a1},flake8,docs
 
 [testenv]
 setenv =
@@ -12,6 +12,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django20a1: Django>=2.0a1,<2.0a2
 commands =
     coverage run --source=django_auth_adfs manage.py test -v 2
     coverage report -m


### PR DESCRIPTION
Django 2.0 [removed is_authenticated as a method](https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#attributes), instead it is now accessed as an attribute.

Not sure if there are other places where 2.0 support is broken, this seems to be the only change needed for our website.

You could also rework the `import MiddlewareMixin ` part (and others) to check the version instead of trying/catching the import, but I'll leave that up to you.