### PR TITLE
support for `?next=` param (after login)

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -12,7 +12,6 @@ from os.path import isfile
 from pprint import pformat
 from requests import post
 from xml.etree import ElementTree
-from django.utils.http import urlencode
 
 from django_auth_adfs.config import settings
 
@@ -136,18 +135,11 @@ class AdfsBackend(ModelBackend):
         if settings.REDIR_URI is None:
             raise ImproperlyConfigured("ADFS Redirect URI is not configured")
 
-        redirect_uri = settings.REDIR_URI
-        if request and request.GET.get(settings.REDIRECT_FIELD_NAME):
-            redirect_uri = '{}?{}'.format(
-                redirect_uri,
-                urlencode({settings.REDIRECT_FIELD_NAME: request.GET.get(settings.REDIRECT_FIELD_NAME)})
-            )
-
         token_url = "https://{0}{1}".format(settings.SERVER, settings.TOKEN_PATH)
         data = {
             'grant_type': 'authorization_code',
             'client_id': settings.CLIENT_ID,
-            'redirect_uri': redirect_uri,
+            'redirect_uri': settings.REDIR_URI,
             'code': authorization_code,
         }
         logger.debug("Authorization code received. Fetching access token.")

--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -22,6 +22,7 @@ class Settings(object):
         self.CLAIM_MAPPING = {}
         self.BOOLEAN_CLAIM_MAPPING = {}
         self.LOGIN_EXEMPT_URLS = []
+        self.REDIRECT_FIELD_NAME = 'next'  # same as django auth
 
         required_settings = [
             "SERVER",

--- a/django_auth_adfs/context_processors.py
+++ b/django_auth_adfs/context_processors.py
@@ -1,4 +1,5 @@
 from django_auth_adfs.util import get_adfs_auth_url
+from django_auth_adfs.config import settings
 
 
 def adfs_url(request):
@@ -13,4 +14,4 @@ def adfs_url(request):
         dict: A dictionary with the ADFS authorization URL
     """
 
-    return {"ADFS_AUTH_URL": get_adfs_auth_url()}
+    return {"ADFS_AUTH_URL": get_adfs_auth_url(next_url=request.GET.get(settings.REDIRECT_FIELD_NAME))}

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -53,4 +53,4 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         if not user_authenticated:
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in LOGIN_EXEMPT_URLS):
-                return HttpResponseRedirect(get_adfs_auth_url())
+                return HttpResponseRedirect(get_adfs_auth_url(next_url=request.path))

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -1,7 +1,10 @@
+from django.utils.http import urlsafe_base64_encode
+
+
 from django_auth_adfs.config import settings
 
 
-def get_adfs_auth_url():
+def get_adfs_auth_url(next_url=None):
     """
     This function returns the ADFS authorization URL.
 
@@ -9,10 +12,13 @@ def get_adfs_auth_url():
         str: The redirect URI
 
     """
-    return "https://{0}{1}?response_type=code&client_id={2}&resource={3}&redirect_uri={4}".format(
+    url = "https://{0}{1}?response_type=code&client_id={2}&resource={3}&redirect_uri={4}".format(
         settings.SERVER,
         settings.AUTHORIZE_PATH,
         settings.CLIENT_ID,
         settings.RESOURCE,
         settings.REDIR_URI,
     )
+    if next_url:
+        url += "&state={0}".format(urlsafe_base64_encode(next_url))
+    return url

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -20,5 +20,5 @@ def get_adfs_auth_url(next_url=None):
         settings.REDIR_URI,
     )
     if next_url:
-        url += "&state={0}".format(urlsafe_base64_encode(next_url))
+        url += "&state={0}".format(urlsafe_base64_encode(next_url.encode()).decode())
     return url

--- a/django_auth_adfs/views.py
+++ b/django_auth_adfs/views.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings as django_settings
 from django.contrib.auth import authenticate, login
 from django.http.response import HttpResponse
@@ -27,10 +28,17 @@ class OAuth2View(View):
 
                 if request.GET.get('state'):  # currently this is only the "next" URL
                     next_url = urlsafe_base64_decode(request.GET.get('state'))
+                    if django.VERSION < (1,11):
+                        hosts_arg = {'host': request.get_host()}
+                    else:
+                        hosts_arg = {
+                            'allowed_hosts': {request.get_host()},
+                            'require_https': request.is_secure()
+                        }
+
                     if is_safe_url(
                         url=next_url,
-                        allowed_hosts={request.get_host()},
-                        require_https=request.is_secure()
+                        **hosts_arg
                     ):
                         return redirect(next_url)
 

--- a/django_auth_adfs/views.py
+++ b/django_auth_adfs/views.py
@@ -27,8 +27,8 @@ class OAuth2View(View):
                 login(request, user)
 
                 if request.GET.get('state'):  # currently this is only the "next" URL
-                    next_url = urlsafe_base64_decode(request.GET.get('state'))
-                    if django.VERSION < (1,11):
+                    next_url = urlsafe_base64_decode(request.GET.get('state')).decode()
+                    if django.VERSION < (1, 11):
                         hosts_arg = {'host': request.get_host()}
                     else:
                         hosts_arg = {
@@ -45,7 +45,7 @@ class OAuth2View(View):
                 # Redirect to the "after login" page.
                 if settings.LOGIN_REDIRECT_URL:
                     return redirect(settings.LOGIN_REDIRECT_URL)
-                
+
                 return redirect(django_settings.LOGIN_REDIRECT_URL)
             else:
                 # Return a 'disabled account' error message

--- a/django_auth_adfs/views.py
+++ b/django_auth_adfs/views.py
@@ -18,15 +18,15 @@ class OAuth2View(View):
         """
         code = request.GET.get("code", None)
 
-        user = authenticate(authorization_code=code)
+        user = authenticate(request=request, authorization_code=code)
 
         if user is not None:
             if user.is_active:
                 login(request, user)
+                if request.GET.get(settings.REDIRECT_FIELD_NAME):
+                    return redirect(request.GET.get(settings.REDIRECT_FIELD_NAME))
                 # Redirect to the "after login" page.
-                # Because we got redirected from ADFS, we can't know where the
-                # user came from.
-                if settings.LOGIN_REDIRECT_URL:
+                elif settings.LOGIN_REDIRECT_URL:
                     return redirect(settings.LOGIN_REDIRECT_URL)
                 else:
                     return redirect(django_settings.LOGIN_REDIRECT_URL)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -38,6 +38,12 @@ class ClientRequestTests(TestCase):
         self.assertTrue(response['Location'].endswith('/accounts/profile/'))
 
     @with_httmock(token_response)
+    def test_authentication_with_next_field(self):
+        response = client.get("/oauth2/login", {'code': 'testcode', 'next': '/other/url'})
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response['Location'].endswith('/other/url'))
+
+    @with_httmock(token_response)
     def test_empty_authentication(self):
         response = client.get("/oauth2/login", {'code': ''})
         self.assertEqual(response.status_code, 401)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -76,3 +76,11 @@ class ClientRequestTests(TestCase):
         self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
                                            b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
                                            b'redirect_uri=example.com\n')
+
+    @with_httmock(token_response)
+    def test_context_processor_with_next(self):
+        response = client.get("/context_processor/?next=/other")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+                                           b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+                                           b'redirect_uri=example.com&amp;state=L290aGVy\n')

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -38,10 +38,10 @@ class ClientRequestTests(TestCase):
         self.assertTrue(response['Location'].endswith('/accounts/profile/'))
 
     @with_httmock(token_response)
-    def test_authentication_with_next_field(self):
-        response = client.get("/oauth2/login", {'code': 'testcode', 'next': '/other/url'})
+    def test_authentication_with_state(self):
+        response = client.get("/oauth2/login", {'code': 'testcode', 'state': 'L3Rlc3Qv'})
         self.assertEqual(response.status_code, 302)
-        self.assertTrue(response['Location'].endswith('/other/url'))
+        self.assertTrue(response['Location'].endswith('/test/'))
 
     @with_httmock(token_response)
     def test_empty_authentication(self):
@@ -67,7 +67,7 @@ class ClientRequestTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
                                                'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
-                                               'redirect_uri=example.com')
+                                               'redirect_uri=example.com&state=L3Rlc3Qv')
 
     @with_httmock(token_response)
     def test_context_processor(self):


### PR DESCRIPTION
Allow `next` field to be passed along with REDIR_URI to ADFS and update JWT token validation to consider it as well