### PR TITLE
added support for multiple REDIRECT_URI

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -14,6 +14,7 @@ from requests import post
 from xml.etree import ElementTree
 
 from django_auth_adfs.config import settings
+from django_auth_adfs.util import get_redirect_uri
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +127,7 @@ class AdfsBackend(ModelBackend):
         """
         cls._public_keys = []
 
-    def authenticate(self, authorization_code=None):
+    def authenticate(self, request=None, authorization_code=None):
         # If there's no token or code, we pass control to the next authentication backend
         if authorization_code is None or authorization_code == '':
             logger.debug("django_auth_adfs was called but no authorization code was received")
@@ -139,7 +140,7 @@ class AdfsBackend(ModelBackend):
         data = {
             'grant_type': 'authorization_code',
             'client_id': settings.CLIENT_ID,
-            'redirect_uri': settings.REDIR_URI,
+            'redirect_uri': get_redirect_uri(hostname=request.get_host() if request else None),
             'code': authorization_code,
         }
         logger.debug("Authorization code received. Fetching access token.")

--- a/django_auth_adfs/context_processors.py
+++ b/django_auth_adfs/context_processors.py
@@ -12,5 +12,4 @@ def adfs_url(request):
     Returns:
         dict: A dictionary with the ADFS authorization URL
     """
-
-    return {"ADFS_AUTH_URL": get_adfs_auth_url()}
+    return {"ADFS_AUTH_URL": get_adfs_auth_url(hostname=request.get_host())}

--- a/django_auth_adfs/middleware.py
+++ b/django_auth_adfs/middleware.py
@@ -53,4 +53,4 @@ class LoginRequiredMiddleware(MiddlewareMixin):
         if not user_authenticated:
             path = request.path_info.lstrip('/')
             if not any(m.match(path) for m in LOGIN_EXEMPT_URLS):
-                return HttpResponseRedirect(get_adfs_auth_url())
+                return HttpResponseRedirect(get_adfs_auth_url(hostname=request.get_host()))

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -19,7 +19,7 @@ def get_adfs_auth_url(hostname=None):
             for uri in settings.REDIR_URI:
                 tmp_uri = uri if '://' in uri else 'x://%s' % uri
                 parsed_uri = urlparse.urlparse(tmp_uri)
-                if parsed_uri.netloc and parsed_uri.netloc.split(':')[0] == hostname:
+                if parsed_uri.netloc == hostname:
                     redir_uri = uri
                     break
 

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -1,7 +1,11 @@
 from django_auth_adfs.config import settings
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 
-def get_adfs_auth_url():
+def get_adfs_auth_url(hostname=None):
     """
     This function returns the ADFS authorization URL.
 
@@ -9,10 +13,25 @@ def get_adfs_auth_url():
         str: The redirect URI
 
     """
+    redir_uri = None
+    if isinstance(settings.REDIR_URI, (list, tuple)):
+        if hostname:
+            for uri in settings.REDIR_URI:
+                tmp_uri = uri if '://' in uri else 'x://%s' % uri
+                parsed_uri = urlparse.urlparse(tmp_uri)
+                if parsed_uri.netloc and parsed_uri.netloc.split(':')[0] == hostname:
+                    redir_uri = uri
+                    break
+
+        if redir_uri is None:
+            redir_uri = settings.REDIR_URI[0]
+    else:
+        redir_uri = settings.REDIR_URI
+    
     return "https://{0}{1}?response_type=code&client_id={2}&resource={3}&redirect_uri={4}".format(
         settings.SERVER,
         settings.AUTHORIZE_PATH,
         settings.CLIENT_ID,
         settings.RESOURCE,
-        settings.REDIR_URI,
+        redir_uri,
     )

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -5,6 +5,18 @@ except ImportError:
     import urllib.parse as urlparse
 
 
+def get_redirect_uri(hostname=None):
+    if isinstance(settings.REDIR_URI, (list, tuple)):
+        if hostname:
+            for uri in settings.REDIR_URI:
+                tmp_uri = uri if '://' in uri else 'x://%s' % uri
+                parsed_uri = urlparse.urlparse(tmp_uri)
+                if parsed_uri.netloc == hostname:
+                    return uri
+        return settings.REDIR_URI[0]
+
+    return settings.REDIR_URI
+
 def get_adfs_auth_url(hostname=None):
     """
     This function returns the ADFS authorization URL.
@@ -13,25 +25,11 @@ def get_adfs_auth_url(hostname=None):
         str: The redirect URI
 
     """
-    redir_uri = None
-    if isinstance(settings.REDIR_URI, (list, tuple)):
-        if hostname:
-            for uri in settings.REDIR_URI:
-                tmp_uri = uri if '://' in uri else 'x://%s' % uri
-                parsed_uri = urlparse.urlparse(tmp_uri)
-                if parsed_uri.netloc == hostname:
-                    redir_uri = uri
-                    break
-
-        if redir_uri is None:
-            redir_uri = settings.REDIR_URI[0]
-    else:
-        redir_uri = settings.REDIR_URI
     
     return "https://{0}{1}?response_type=code&client_id={2}&resource={3}&redirect_uri={4}".format(
         settings.SERVER,
         settings.AUTHORIZE_PATH,
         settings.CLIENT_ID,
         settings.RESOURCE,
-        redir_uri,
+        get_redirect_uri(hostname),
     )

--- a/django_auth_adfs/util.py
+++ b/django_auth_adfs/util.py
@@ -17,6 +17,7 @@ def get_redirect_uri(hostname=None):
 
     return settings.REDIR_URI
 
+
 def get_adfs_auth_url(hostname=None):
     """
     This function returns the ADFS authorization URL.
@@ -25,7 +26,7 @@ def get_adfs_auth_url(hostname=None):
         str: The redirect URI
 
     """
-    
+
     return "https://{0}{1}?response_type=code&client_id={2}&resource={3}&redirect_uri={4}".format(
         settings.SERVER,
         settings.AUTHORIZE_PATH,

--- a/django_auth_adfs/views.py
+++ b/django_auth_adfs/views.py
@@ -18,7 +18,7 @@ class OAuth2View(View):
         """
         code = request.GET.get("code", None)
 
-        user = authenticate(authorization_code=code)
+        user = authenticate(request=request, authorization_code=code)
 
         if user is not None:
             if user.is_active:

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -66,9 +66,9 @@ class ClientRequestTests(TestCase):
 
     @with_httmock(token_response)
     def test_login_redir_multiple(self):
-        base_content = b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-        base_content += b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-        base_content += b'redirect_uri=%s\n'
+        base_content = 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+        base_content += 'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+        base_content += 'redirect_uri=%s\n'
 
         base_location = 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
         base_location += 'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
@@ -81,13 +81,13 @@ class ClientRequestTests(TestCase):
             ):
                 response = client.get("/context_processor/", HTTP_HOST="other-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % b'other-example.com')
+                self.assertEqual(response.content, (base_content % 'other-example.com').encode())
                 response = client.get("/context_processor/", HTTP_HOST="example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % b'example.com')
+                self.assertEqual(response.content, (base_content % 'example.com').encode())
                 response = client.get("/context_processor/", HTTP_HOST="something-else-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % b'example.com')
+                self.assertEqual(response.content, (base_content % 'example.com').encode())
 
                 response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
                 self.assertEqual(response.status_code, 302)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -66,29 +66,30 @@ class ClientRequestTests(TestCase):
 
     @with_httmock(token_response)
     def test_login_redir_multiple(self):
-        with patch("django_auth_adfs.backend.settings.REDIR_URI", ["example.com", "other-example.com", "example.com:8080"]):
-            response = client.get("/context_processor/", HTTP_HOST="other-example.com")
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                               b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                               b'redirect_uri=other-example.com\n')
-            response = client.get("/testMiddleware/", HTTP_HOST="other-example.com")
-            response = client.get("/context_processor/", HTTP_HOST="example.com")
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                               b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                               b'redirect_uri=example.com\n')
-            response = client.get("/context_processor/", HTTP_HOST="something-else-example.com")
-            self.assertEqual(response.status_code, 200)
-            self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                               b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                               b'redirect_uri=example.com\n')
+        with self.settings(ALLOWED_HOSTS=['*']):
+            with patch("django_auth_adfs.backend.settings.REDIR_URI", ["example.com", "other-example.com", "example.com:8080"]):
+                response = client.get("/context_processor/", HTTP_HOST="other-example.com")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+                                                   b'redirect_uri=other-example.com\n')
+                response = client.get("/testMiddleware/", HTTP_HOST="other-example.com")
+                response = client.get("/context_processor/", HTTP_HOST="example.com")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+                                                   b'redirect_uri=example.com\n')
+                response = client.get("/context_processor/", HTTP_HOST="something-else-example.com")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+                                                   b'redirect_uri=example.com\n')
 
-            response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
-            self.assertEqual(response.status_code, 302)
-            self.assertEqual(response["Location"], 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
-                                               'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
-                                               'redirect_uri=example.com:8080')
+                response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(response["Location"], 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
+                                                   'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
+                                                   'redirect_uri=example.com:8080')
 
     @with_httmock(token_response)
     def test_context_processor(self):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -66,12 +66,13 @@ class ClientRequestTests(TestCase):
 
     @with_httmock(token_response)
     def test_login_redir_multiple(self):
-        with patch("django_auth_adfs.backend.settings.REDIR_URI", ["example.com", "other-example.com"]):
+        with patch("django_auth_adfs.backend.settings.REDIR_URI", ["example.com", "other-example.com", "example.com:8080"]):
             response = client.get("/context_processor/", HTTP_HOST="other-example.com")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
                                                b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
                                                b'redirect_uri=other-example.com\n')
+            response = client.get("/testMiddleware/", HTTP_HOST="other-example.com")
             response = client.get("/context_processor/", HTTP_HOST="example.com")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
@@ -82,6 +83,12 @@ class ClientRequestTests(TestCase):
             self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
                                                b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
                                                b'redirect_uri=example.com\n')
+
+            response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response["Location"], 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
+                                               'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
+                                               'redirect_uri=example.com:8080')
 
     @with_httmock(token_response)
     def test_context_processor(self):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -66,30 +66,33 @@ class ClientRequestTests(TestCase):
 
     @with_httmock(token_response)
     def test_login_redir_multiple(self):
+        base_content = b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
+        base_content += b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
+        base_content += b'redirect_uri=%s\n'
+
+        base_location = 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
+        base_location += 'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
+        base_location += 'redirect_uri=%s'
+
         with self.settings(ALLOWED_HOSTS=['*']):
-            with patch("django_auth_adfs.backend.settings.REDIR_URI", ["example.com", "other-example.com", "example.com:8080"]):
+            with patch(
+                "django_auth_adfs.backend.settings.REDIR_URI",
+                ["example.com", "other-example.com", "example.com:8080"]
+            ):
                 response = client.get("/context_processor/", HTTP_HOST="other-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                                   b'redirect_uri=other-example.com\n')
+                self.assertEqual(response.content, base_content % 'other-example.com')
                 response = client.get("/testMiddleware/", HTTP_HOST="other-example.com")
                 response = client.get("/context_processor/", HTTP_HOST="example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                                   b'redirect_uri=example.com\n')
+                self.assertEqual(response.content, base_content % 'example.com')
                 response = client.get("/context_processor/", HTTP_HOST="something-else-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, b'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&amp;'
-                                                   b'client_id=your-configured-client-id&amp;resource=your-adfs-RPT-name&amp;'
-                                                   b'redirect_uri=example.com\n')
+                self.assertEqual(response.content, base_content % 'example.com')
 
                 response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
                 self.assertEqual(response.status_code, 302)
-                self.assertEqual(response["Location"], 'https://adfs.example.com/adfs/oauth2/authorize?response_type=code&'
-                                                   'client_id=your-configured-client-id&resource=your-adfs-RPT-name&'
-                                                   'redirect_uri=example.com:8080')
+                self.assertEqual(response["Location"], base_location % 'example.com:8080')
 
     @with_httmock(token_response)
     def test_context_processor(self):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -81,14 +81,13 @@ class ClientRequestTests(TestCase):
             ):
                 response = client.get("/context_processor/", HTTP_HOST="other-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % 'other-example.com')
-                response = client.get("/testMiddleware/", HTTP_HOST="other-example.com")
+                self.assertEqual(response.content, base_content % b'other-example.com')
                 response = client.get("/context_processor/", HTTP_HOST="example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % 'example.com')
+                self.assertEqual(response.content, base_content % b'example.com')
                 response = client.get("/context_processor/", HTTP_HOST="something-else-example.com")
                 self.assertEqual(response.status_code, 200)
-                self.assertEqual(response.content, base_content % 'example.com')
+                self.assertEqual(response.content, base_content % b'example.com')
 
                 response = client.get("/testMiddleware/", HTTP_HOST="example.com:8080")
                 self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
ADFS client configuration supports setting multiple `REDIRECT_URI`s.  
This is useful as the same code might be exposed in different domains.

In my case (one possible scenario) users access it using internal domain or external domain and I need the redirect to continue in the same domain users started from.

This is a simple change keeping backwards compatibility (checking if settings REDIR_URI is list or not)