### PR TITLE
Include templates in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
+recursive-include django_auth_adfs/templates *.html
 recursive-include docs *.rst conf.py Makefile make.bat
 recursive-include docs/_static *
 recursive-include docs/_templates *


### PR DESCRIPTION
Without this when installing from source the template(s) were not included.