### PR TITLE
Print the claim value instead of the name

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -130,7 +130,7 @@ class AdfsBackend(ModelBackend):
             usermodel.USERNAME_FIELD: claims[username_claim]
         })
         if created:
-            logging.debug("User '{}' has been created.".format(username_claim))
+            logging.debug("User '{}' has been created.".format(claims[username_claim]))
 
         return user
 


### PR DESCRIPTION
Currently the name of the claim is logged.