### PR TITLE
Fix wrong signal import, removed full_clean

### DIFF
--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -73,7 +73,8 @@ class AdfsBackend(ModelBackend):
             sender=self,
             user=user,
             claims=claims,
-            adfs_response=adfs_response
+            adfs_response=adfs_response,
+            **kwargs
         )
 
         user.save()

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -73,8 +73,7 @@ class AdfsBackend(ModelBackend):
             sender=self,
             user=user,
             claims=claims,
-            adfs_response=adfs_response,
-            **kwargs
+            adfs_response=adfs_response
         )
 
         user.save()

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -76,7 +76,6 @@ class AdfsBackend(ModelBackend):
             adfs_response=adfs_response
         )
 
-        user.full_clean()
         user.save()
         return user
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 
 from django_auth_adfs.backend import AdfsBackend
 from django_auth_adfs.config import ProviderConfig, Settings
-from django_auth_adfs.signals import adfs_backend_post_authenticate
+from django_auth_adfs.signals import post_authenticate
 
 from .utils import mock_adfs
 
@@ -18,7 +18,7 @@ class AuthenticationTests(TestCase):
         Group.objects.create(name='group3')
         self.request = RequestFactory().get('/oauth2/callback')
         self.signal_handler = Mock()
-        adfs_backend_post_authenticate.connect(self.signal_handler)
+        post_authenticate.connect(self.signal_handler)
 
     @mock_adfs("2012")
     def test_post_authenticate_signal_send(self):


### PR DESCRIPTION
The `post_authenticate` signal was renamed so this is now renamed in the tests as well.

The `full_clean` call is a good idea but it breaks the when you use the default django user without setting a password:
```python
ERROR: test_with_auth_code_azure (tests.test_authentication.AuthenticationTests)
Traceback (most recent call last):
  File "/Users/martijn/Dev/oss/django-auth-adfs/tests/utils.py", line 211, in wrapper
    test_func(*original_args, **original_kwargs)
  File "/Users/martijn/Dev/oss/django-auth-adfs/tests/test_authentication.py", line 63, in test_with_auth_code_azure
    user = backend.authenticate(self.request, authorization_code="dummycode")
  File "/Users/martijn/Dev/oss/django-auth-adfs/django_auth_adfs/backend.py", line 79, in authenticate
    user.full_clean()
  File "/Users/martijn/.pyenv/versions/django-auth-adfs/lib/python3.7/site-packages/django/db/models/base.py", line 1152, in full_clean
    raise ValidationError(errors)
django.core.exceptions.ValidationError: {'password': ['This field cannot be blank.']}
```

 As the `full_clean` was not there before I removed it for now so the tests pass again.