### PR TITLE
Django Rest Framework tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,48 +4,88 @@ language: python
 matrix:
     include:
         - python: 2.7
-          env: TOXENV=py27-django18
+          env: TOXENV=py27-django18-drf36
         - python: 2.7
-          env: TOXENV=py27-django19
+          env: TOXENV=py27-django19-drf36
         - python: 2.7
-          env: TOXENV=py27-django110
+          env: TOXENV=py27-django110-drf37
         - python: 2.7
-          env: TOXENV=py27-django111
+          env: TOXENV=py27-django110-drf38
+        - python: 2.7
+          env: TOXENV=py27-django111-drf37
+        - python: 2.7
+          env: TOXENV=py27-django111-drf38
+        - python: 2.7
+          env: TOXENV=py27-django111-drf39
 
         - python: 3.4
-          env: TOXENV=py34-django18
+          env: TOXENV=py34-django18-drf36
         - python: 3.4
-          env: TOXENV=py34-django19
+          env: TOXENV=py34-django19-drf36
         - python: 3.4
-          env: TOXENV=py34-django110
+          env: TOXENV=py34-django110-drf37
         - python: 3.4
-          env: TOXENV=py34-django111
+          env: TOXENV=py34-django110-drf38
+        - python: 3.4
+          env: TOXENV=py34-django111-drf37
+        - python: 3.4
+          env: TOXENV=py34-django111-drf38
+        - python: 3.4
+          env: TOXENV=py34-django111-drf39
 
         - python: 3.5
-          env: TOXENV=py35-django18
+          env: TOXENV=py35-django18-drf36
         - python: 3.5
-          env: TOXENV=py35-django19
+          env: TOXENV=py35-django19-drf36
         - python: 3.5
-          env: TOXENV=py35-django110
+          env: TOXENV=py35-django110-drf37
         - python: 3.5
-          env: TOXENV=py35-django111
+          env: TOXENV=py35-django110-drf38
         - python: 3.5
-          env: TOXENV=py35-django20
+          env: TOXENV=py35-django111-drf37
         - python: 3.5
-          env: TOXENV=py35-django21
+          env: TOXENV=py35-django111-drf38
+        - python: 3.5
+          env: TOXENV=py35-django111-drf39
+        - python: 3.5
+          env: TOXENV=py35-django20-drf37
+        - python: 3.5
+          env: TOXENV=py35-django20-drf38
+        - python: 3.5
+          env: TOXENV=py35-django20-drf39
+        - python: 3.5
+          env: TOXENV=py35-django21-drf37
+        - python: 3.5
+          env: TOXENV=py35-django21-drf38
+        - python: 3.5
+          env: TOXENV=py35-django21-drf39
 
         - python: 3.6
-          env: TOXENV=py36-django18
+          env: TOXENV=py36-django18-drf36
         - python: 3.6
-          env: TOXENV=py36-django19
+          env: TOXENV=py36-django19-drf36
         - python: 3.6
-          env: TOXENV=py36-django110
+          env: TOXENV=py36-django110-drf37
         - python: 3.6
-          env: TOXENV=py36-django111
+          env: TOXENV=py36-django110-drf38
         - python: 3.6
-          env: TOXENV=py36-django20
+          env: TOXENV=py36-django111-drf37
         - python: 3.6
-          env: TOXENV=py36-django21
+          env: TOXENV=py36-django111-drf38
+        - python: 3.6
+          env: TOXENV=py36-django111-drf39
+        - python: 3.6
+          env: TOXENV=py36-django20-drf37
+        - python: 3.6
+          env: TOXENV=py36-django20-drf38
+        - python: 3.6
+          env: TOXENV=py36-django20-drf39
+        - python: 3.6
+          env: TOXENV=py36-django21-drf37
+        - python: 3.6
+          env: TOXENV=py36-django21-drf38
+        - python: 3.6
+          env: TOXENV=py36-django21-drf39
 
         - python: 3.6
           env: TOXENV=flake8

--- a/django_auth_adfs/backend.py
+++ b/django_auth_adfs/backend.py
@@ -250,7 +250,7 @@ class AdfsAuthCodeBackend(AdfsBaseBackend):
     Microsoft ADFS server with an authorization code.
     """
 
-    def authenticate(self, request, authorization_code=None, **kwargs):
+    def authenticate(self, request=None, authorization_code=None, **kwargs):
         # If loaded data is too old, reload it again
         provider_config.load_config()
 
@@ -271,7 +271,7 @@ class AdfsAccessTokenBackend(AdfsBaseBackend):
     Microsoft ADFS server with an access token retrieved by the client.
     """
 
-    def authenticate(self, request, access_token=None, **kwargs):
+    def authenticate(self, request=None, access_token=None, **kwargs):
         # If loaded data is too old, reload it again
         provider_config.load_config()
 

--- a/django_auth_adfs/rest_framework.py
+++ b/django_auth_adfs/rest_framework.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 from django.contrib.auth import authenticate

--- a/docs/rest_framework.rst
+++ b/docs/rest_framework.rst
@@ -7,6 +7,20 @@ Setup
 When using Django Rest Framework, you can also use this package to authenticate
 your REST API clients. For this you need to do some extra configuration.
 
+You also need to install ``djangorestframework`` (or add it to your
+project dependencies)::
+
+    pip install djangorestframework
+
+The default ``AdfsBackend`` backend expects an ``authorization_code``. The backend
+will take care of obtaining an ``access_code`` from the Adfs server.
+
+With the Django Rest Framework integration the client application needs to acquire
+the access token by itself. See for an example: :ref:`request-access-token`. To
+authenticate against the API you need to enable the ``AdfsAccessTokenBackend``.
+
+Steps to enable the Django Rest Framework integration are as following:
+
 Add an extra authentication class to Django Rest Framework in ``settings.py``:
 
 .. code-block:: python
@@ -17,6 +31,16 @@ Add an extra authentication class to Django Rest Framework in ``settings.py``:
             'rest_framework.authentication.SessionAuthentication',
         )
     }
+
+Enable the ``AdfsAccessTokenBackend`` authentication backend in ``settings.py``:
+
+.. code-block:: python
+
+    AUTHENTICATION_BACKENDS = (
+        ...
+        'django_auth_adfs.backend.AdfsAccessTokenBackend',
+        ...
+    )
 
 (Optional) Override the standard Django Rest Framework login pages in your main ``urls.py``:
 
@@ -35,10 +59,13 @@ Add an extra authentication class to Django Rest Framework in ``settings.py``:
         ...
     ]
 
+.. _request-access-token:
+
 Requesting an access token
 --------------------------
 
-When everything is configured, you can request an access token in your client (script) like this:
+When everything is configured, you can request an access token in your client (script) and
+access the api like this:
 
 .. code-block:: python
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = (
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
     'django_auth_adfs.backend.AdfsBackend',
+    'django_auth_adfs.backend.AdfsAccessTokenBackend'
 )
 
 ROOT_URLCONF = 'tests.urls'

--- a/tests/test_drf_integration.py
+++ b/tests/test_drf_integration.py
@@ -1,0 +1,73 @@
+import json
+from copy import deepcopy
+
+from django.test import RequestFactory, TestCase
+
+from django_auth_adfs.config import ProviderConfig, Settings
+from django_auth_adfs.rest_framework import AdfsAccessTokenAuthentication
+
+from mock import patch
+
+from rest_framework import exceptions
+
+
+from .utils import build_access_token_adfs, build_access_token_azure, mock_adfs
+
+
+class RestFrameworkIntegrationTests(TestCase):
+    def setUp(self):
+        self.drf_auth_class = AdfsAccessTokenAuthentication()
+
+        adfs_response = build_access_token_adfs(RequestFactory().get('/'))[2]
+        self.access_token_adfs = json.loads(adfs_response)['access_token']
+
+        azure_response = build_access_token_azure(RequestFactory().get('/'))[2]
+        self.access_token_azure = json.loads(azure_response)['access_token']
+
+    @mock_adfs("2012")
+    def test_access_token_2012(self):
+        access_token_header = "Bearer {}".format(self.access_token_adfs)
+        request = RequestFactory().get('/api', HTTP_AUTHORIZATION=access_token_header)
+
+        user, token = self.drf_auth_class.authenticate(request)
+        self.assertEqual(user.username, "testuser")
+        self.assertEqual(token, self.access_token_adfs.encode())
+
+    @mock_adfs("2016")
+    def test_access_token_2016(self):
+        access_token_header = "Bearer {}".format(self.access_token_adfs)
+        request = RequestFactory().get('/api', HTTP_AUTHORIZATION=access_token_header)
+
+        user, token = self.drf_auth_class.authenticate(request)
+        self.assertEqual(user.username, "testuser")
+        self.assertEqual(token, self.access_token_adfs.encode())
+
+    @mock_adfs("azure")
+    def test_access_token_azure(self):
+        access_token_header = "Bearer {}".format(self.access_token_azure)
+        request = RequestFactory().get('/api', HTTP_AUTHORIZATION=access_token_header)
+
+        from django_auth_adfs.config import django_settings
+        settings = deepcopy(django_settings)
+        del settings.AUTH_ADFS["SERVER"]
+        settings.AUTH_ADFS["TENANT_ID"] = "dummy_tenant_id"
+        with patch("django_auth_adfs.config.django_settings", settings):
+            with patch("django_auth_adfs.config.settings", Settings()):
+                with patch("django_auth_adfs.backend.provider_config", ProviderConfig()):
+                    user, token = self.drf_auth_class.authenticate(request)
+                    self.assertEqual(user.username, "testuser")
+
+    @mock_adfs("2012")
+    def test_access_token_exceptions(self):
+        access_token_header = "Bearer non-existing-token"
+        request = RequestFactory().get('/api', HTTP_AUTHORIZATION=access_token_header)
+
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            self.drf_auth_class.authenticate(request)
+
+        # use the azure token on adfs should not work
+        access_token_header = "Bearer {}".format(self.access_token_azure)
+        request = RequestFactory().get('/api', HTTP_AUTHORIZATION=access_token_header)
+
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            self.drf_auth_class.authenticate(request)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,11 @@
 [tox]
-envlist = py{27,34,35,36}-django{18,19,110,111},py{35,36}-django{20,21},flake8,docs
+envlist =
+    py{27,34,35,36}-django{18,19}-drf{36}
+    py{27,34,35,36}-django{110}-drf{37,38}
+    py{27,34,35,36}-django{111}-drf{37,38,39}
+    py{35,36}-django{20,21}-drf{37,38,39}
+    flake8
+    docs
 
 [testenv]
 deps =
@@ -12,6 +18,10 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    drf36: djangorestframework>=3.6,<3.7
+    drf37: djangorestframework>=3.7,<3.8
+    drf38: djangorestframework>=3.8,<3.9
+    drf39: djangorestframework>=3.9<3.10
 commands =
     coverage run manage.py test -v 2
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist = py{27,34,35,36}-django{18,19,110,111},py{35,36}-django{20,21},flake8,docs
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/django_auth_adfs
 deps =
     coverage
     mock


### PR DESCRIPTION
<del>This pull request is a bit drastic. It  includes #60 as well so you can ignore that one if you agree on this one (or the other way around)</del>
<del>
Adding `djangorestframework` support for older Django versions (<1.11) would be a lot of work.
</del>
<del>
And this all for Django versions which are not supported anymore, they don't receive any security updates and it's highly recommended not to use them anymore.
</del>
<del>
So that is why I removed Django versions < 1.11 in travis / tox / setup.py 
</del>
<del>
I also needed to rename `rest_framework.py` because in python 2.7 it will clash with the `rest_framework` namespace from django rest framework itself (`from rest_framework import exceptions` for example).
</del>

This pull request adds test for the DRF support. Some small documentation improvements are added as well. 

It also fixes an small import issue with python 2.7.