### PR TITLE
Add support for custom Setting provider implementations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+`1.3.0`_ - 2019-03-??
+---------------------
+
+**Added**
+
+* Added setting ``SETTINGS_CLASS``, defaulting to
+  ``django_auth_adfs.config.Settings``. This provides a mechanism to load the
+  ``AUTH_ADFS`` config from sources other than Django settings.
+
 `1.2.0`_ - 2019-03-01
 ---------------------
 
@@ -155,6 +164,7 @@ Changelog
 
 * Initial release
 
+.. _1.3.0: https://github.com/jobec/django-auth-adfs/compare/1.2.0...1.3.0
 .. _1.2.0: https://github.com/jobec/django-auth-adfs/compare/1.1.2...1.2.0
 .. _1.1.2: https://github.com/jobec/django-auth-adfs/compare/1.1.1...1.1.2
 .. _1.1.1: https://github.com/jobec/django-auth-adfs/compare/1.0.0...1.1.1

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -350,10 +350,10 @@ and point to it by using the ``SETTINGS_CLASS`` setting:
         ...
 
 
-    # in settings
+    # in settings.py
 
     AUTH_ADFS = {
-        'SETTINGS_CLASS': 'myapp.adfs.config',
+        'SETTINGS_CLASS': 'myapp.adfs.config.CustomSettings',
         # other settings are not needed
     }
 

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -330,3 +330,35 @@ The value of the claim must be a unique value. No 2 users should ever have the s
    You can find the short name for the claims you configure in the ADFS management console underneath
    **ADFS** ➜ **Service** ➜ **Claim Descriptions**
 
+SETTINGS_CLASS
+--------------
+* **Default**: ``django_auth_adfs.config.Settings``
+* **Type**: ``string``
+
+By default, django-auth-adfs reads the configuration from the Django setting
+``AUTH_ADFS``. You can provide the configuration in a custom implementation
+and point to it by using the ``SETTINGS_CLASS`` setting:
+
+.. code-block:: python
+
+    # in myapp.adfs.config
+
+    class CustomSettings:
+
+        SERVER = 'bar'
+        AUDIENCE = 'foo'
+        ...
+
+
+    # in settings
+
+    AUTH_ADFS = {
+        'SETTINGS_CLASS': 'myapp.adfs.config',
+        # other settings are not needed
+    }
+
+The value must be an importable dotted Python path, and the imported object
+must be callable with no arguments to initialize.
+
+Use cases are storing configuration in database so an administrator can edit
+the configuration in an admin interface.

--- a/docs/settings_ref.rst
+++ b/docs/settings_ref.rst
@@ -283,6 +283,39 @@ The FQDN of the ADFS server you want users to authenticate against.
 
 .. _tenant_id_setting:
 
+SETTINGS_CLASS
+--------------
+* **Default**: ``django_auth_adfs.config.Settings``
+* **Type**: ``string``
+
+By default, django-auth-adfs reads the configuration from the Django setting
+``AUTH_ADFS``. You can provide the configuration in a custom implementation
+and point to it by using the ``SETTINGS_CLASS`` setting:
+
+.. code-block:: python
+
+    # in myapp.adfs.config
+
+    class CustomSettings:
+
+        SERVER = 'bar'
+        AUDIENCE = 'foo'
+        ...
+
+
+    # in settings.py
+
+    AUTH_ADFS = {
+        'SETTINGS_CLASS': 'myapp.adfs.config.CustomSettings',
+        # other settings are not needed
+    }
+
+The value must be an importable dotted Python path, and the imported object
+must be callable with no arguments to initialize.
+
+Use cases are storing configuration in database so an administrator can edit
+the configuration in an admin interface.
+
 TENANT_ID
 ---------
 * **Default**:
@@ -329,36 +362,3 @@ The value of the claim must be a unique value. No 2 users should ever have the s
 .. NOTE::
    You can find the short name for the claims you configure in the ADFS management console underneath
    **ADFS** ➜ **Service** ➜ **Claim Descriptions**
-
-SETTINGS_CLASS
---------------
-* **Default**: ``django_auth_adfs.config.Settings``
-* **Type**: ``string``
-
-By default, django-auth-adfs reads the configuration from the Django setting
-``AUTH_ADFS``. You can provide the configuration in a custom implementation
-and point to it by using the ``SETTINGS_CLASS`` setting:
-
-.. code-block:: python
-
-    # in myapp.adfs.config
-
-    class CustomSettings:
-
-        SERVER = 'bar'
-        AUDIENCE = 'foo'
-        ...
-
-
-    # in settings.py
-
-    AUTH_ADFS = {
-        'SETTINGS_CLASS': 'myapp.adfs.config.CustomSettings',
-        # other settings are not needed
-    }
-
-The value must be an importable dotted Python path, and the imported object
-must be callable with no arguments to initialize.
-
-Use cases are storing configuration in database so an administrator can edit
-the configuration in an admin interface.

--- a/tests/custom_config.py
+++ b/tests/custom_config.py
@@ -1,0 +1,6 @@
+class Settings(object):
+    RETRIES = 1
+    CA_BUNDLE = False
+
+    def __init__(self):
+        self.SERVER = 'custom-server'

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,72 +2,52 @@ import sys
 from copy import deepcopy
 
 from django.core.exceptions import ImproperlyConfigured
-from django.test import SimpleTestCase, override_settings
+from django.test import TestCase, SimpleTestCase, override_settings
 from mock import patch
 from django_auth_adfs.config import django_settings
-
+from django_auth_adfs.config import Settings
 from .custom_config import Settings as CustomSettings
 
 
-class ReloadModuleMixin(object):
-    # force re-import and thus module re-evaluation
+class SettingsTests(TestCase):
+    def test_no_settings(self):
+        settings = deepcopy(django_settings)
+        del settings.AUTH_ADFS
+        with patch("django_auth_adfs.config.django_settings", settings):
+            self.assertRaises(ImproperlyConfigured, Settings)
+
+    def test_claim_mapping_overlapping_username_field(self):
+        settings = deepcopy(django_settings)
+        settings.AUTH_ADFS["CLAIM_MAPPING"] = {"username": "samaccountname"}
+        with patch("django_auth_adfs.config.django_settings", settings):
+            self.assertRaises(ImproperlyConfigured, Settings)
+
+    def test_tenant_and_server(self):
+        settings = deepcopy(django_settings)
+        settings.AUTH_ADFS["TENEANT_ID"] = "abc"
+        settings.AUTH_ADFS["server"] = "abc"
+        with patch("django_auth_adfs.config.django_settings", settings):
+            self.assertRaises(ImproperlyConfigured, Settings)
+
+    def test_unknown_setting(self):
+        settings = deepcopy(django_settings)
+        settings.AUTH_ADFS["dummy"] = "abc"
+        with patch("django_auth_adfs.config.django_settings", settings):
+            self.assertRaises(ImproperlyConfigured, Settings)
+
+    def test_required_setting(self):
+        settings = deepcopy(django_settings)
+        del settings.AUTH_ADFS["AUDIENCE"]
+        with patch("django_auth_adfs.config.django_settings", settings):
+            self.assertRaises(ImproperlyConfigured, Settings)
+
+
+class CustomSettingsTests(SimpleTestCase):
     def setUp(self):
         sys.modules.pop('django_auth_adfs.config', None)
 
     def tearDown(self):
         sys.modules.pop('django_auth_adfs.config', None)
-
-
-class SettingsTests(ReloadModuleMixin, SimpleTestCase):
-
-    def test_no_settings(self):
-        from django_auth_adfs.config import Settings
-
-        settings = deepcopy(django_settings)
-        del settings.AUTH_ADFS
-        with patch("django_auth_adfs.config.django_settings", settings):
-
-            self.assertRaises(ImproperlyConfigured, Settings)
-
-    def test_claim_mapping_overlapping_username_field(self):
-        from django_auth_adfs.config import Settings
-
-        settings = deepcopy(django_settings)
-        settings.AUTH_ADFS["CLAIM_MAPPING"] = {"username": "samaccountname"}
-        with patch("django_auth_adfs.config.django_settings", settings):
-
-            self.assertRaises(ImproperlyConfigured, Settings)
-
-    def test_tenant_and_server(self):
-        from django_auth_adfs.config import Settings
-
-        settings = deepcopy(django_settings)
-        settings.AUTH_ADFS["TENEANT_ID"] = "abc"
-        settings.AUTH_ADFS["server"] = "abc"
-        with patch("django_auth_adfs.config.django_settings", settings):
-
-            self.assertRaises(ImproperlyConfigured, Settings)
-
-    def test_unknown_setting(self):
-        from django_auth_adfs.config import Settings
-
-        settings = deepcopy(django_settings)
-        settings.AUTH_ADFS["dummy"] = "abc"
-        with patch("django_auth_adfs.config.django_settings", settings):
-
-            self.assertRaises(ImproperlyConfigured, Settings)
-
-    def test_required_setting(self):
-        from django_auth_adfs.config import Settings
-
-        settings = deepcopy(django_settings)
-        del settings.AUTH_ADFS["AUDIENCE"]
-        with patch("django_auth_adfs.config.django_settings", settings):
-
-            self.assertRaises(ImproperlyConfigured, Settings)
-
-
-class CustomSettingsTests(ReloadModuleMixin, SimpleTestCase):
 
     def test_dotted_path(self):
         auth_adfs = deepcopy(django_settings).AUTH_ADFS
@@ -75,5 +55,4 @@ class CustomSettingsTests(ReloadModuleMixin, SimpleTestCase):
 
         with override_settings(AUTH_ADFS=auth_adfs):
             from django_auth_adfs.config import settings
-
             self.assertIsInstance(settings, CustomSettings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,40 +1,79 @@
+import sys
 from copy import deepcopy
 
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase
+from django.test import SimpleTestCase, override_settings
 from mock import patch
 from django_auth_adfs.config import django_settings
-from django_auth_adfs.config import Settings
+
+from .custom_config import Settings as CustomSettings
 
 
-class SettingsTests(TestCase):
+class ReloadModuleMixin(object):
+    # force re-import and thus module re-evaluation
+    def setUp(self):
+        sys.modules.pop('django_auth_adfs.config', None)
+
+    def tearDown(self):
+        sys.modules.pop('django_auth_adfs.config', None)
+
+
+class SettingsTests(ReloadModuleMixin, SimpleTestCase):
+
     def test_no_settings(self):
+        from django_auth_adfs.config import Settings
+
         settings = deepcopy(django_settings)
         del settings.AUTH_ADFS
         with patch("django_auth_adfs.config.django_settings", settings):
+
             self.assertRaises(ImproperlyConfigured, Settings)
 
     def test_claim_mapping_overlapping_username_field(self):
+        from django_auth_adfs.config import Settings
+
         settings = deepcopy(django_settings)
         settings.AUTH_ADFS["CLAIM_MAPPING"] = {"username": "samaccountname"}
         with patch("django_auth_adfs.config.django_settings", settings):
+
             self.assertRaises(ImproperlyConfigured, Settings)
 
     def test_tenant_and_server(self):
+        from django_auth_adfs.config import Settings
+
         settings = deepcopy(django_settings)
         settings.AUTH_ADFS["TENEANT_ID"] = "abc"
         settings.AUTH_ADFS["server"] = "abc"
         with patch("django_auth_adfs.config.django_settings", settings):
+
             self.assertRaises(ImproperlyConfigured, Settings)
 
     def test_unknown_setting(self):
+        from django_auth_adfs.config import Settings
+
         settings = deepcopy(django_settings)
         settings.AUTH_ADFS["dummy"] = "abc"
         with patch("django_auth_adfs.config.django_settings", settings):
+
             self.assertRaises(ImproperlyConfigured, Settings)
 
     def test_required_setting(self):
+        from django_auth_adfs.config import Settings
+
         settings = deepcopy(django_settings)
         del settings.AUTH_ADFS["AUDIENCE"]
         with patch("django_auth_adfs.config.django_settings", settings):
+
             self.assertRaises(ImproperlyConfigured, Settings)
+
+
+class CustomSettingsTests(ReloadModuleMixin, SimpleTestCase):
+
+    def test_dotted_path(self):
+        auth_adfs = deepcopy(django_settings).AUTH_ADFS
+        auth_adfs['SETTINGS_CLASS'] = 'tests.custom_config.Settings'
+
+        with override_settings(AUTH_ADFS=auth_adfs):
+            from django_auth_adfs.config import settings
+
+            self.assertIsInstance(settings, CustomSettings)


### PR DESCRIPTION
In simple words: we want the ADFS configuration to be editable in the admin, and this feature facilitates this.


Long read:
While looking at the code, I noticed a nice separation of `ProviderConfig` and `Settings`, where the former makes use of the instance/sentinel of the latter. The `Settings` are populated from the Django Settings - all very reasonable.

However, ADFS will be only one of many backends we support, so we want to be able to enable/disable it at runtime and make it possible to configure against Azure or on-premise _without_ having to redeploy. This essentially means that environment variables are out of the question, and we're probabling going to leverage django-solo to store the config.

By implementing our own `SoloSettings` class, which exposes the same attributes as the Django-settings based on, this _should_ be a drop-in replacement, that gives no extra maintenance burden to django-auth-adfs. This PR only facilitates us to specify our own `Settings` implementation.

**Changes**:

* Added a Django setting to specify which Settings class to use
* Default is the one that was currently used
* Added tests + modified existing tests
* Added documentation