### PR TITLE
Added support for enterprise app sso certificates

### DIFF
--- a/django_auth_adfs/config.py
+++ b/django_auth_adfs/config.py
@@ -203,8 +203,8 @@ class ProviderConfig(object):
             logger.info("issuer:                 " + self.issuer)
 
     def _load_openid_config(self):
-        config_url = "https://{}/{}/.well-known/openid-configuration".format(
-            settings.SERVER, settings.TENANT_ID
+        config_url = "https://{}/{}/.well-known/openid-configuration?appid={}".format(
+            settings.SERVER, settings.TENANT_ID, settings.CLIENT_ID
         )
 
         try:


### PR DESCRIPTION
When an app is registered as an Azure Enterprise app and SSO is turned on, Azure uses a different set of certificates to sign the resulting issued tokens.

The standard certificates are reached via:
https://login.microsoftonline.com/TENANT_ID/.well-known/openid-configuration.
However, when SSO is turned on, a different cert is used not present in the above list. Instead you can reach the correct certificate list using:
https://login.microsoftonline.com/TENANT_ID/.well-known/openid-configuration?appid=CLIENT_ID

As it happens, even if SSO is *not* turned on, the second of these URL options still returns the correct certificate list.

We bumped into this in a recent deployment and so I offer this addition to enable the package to work in both scenarios.